### PR TITLE
Add a flashlight button

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -48,10 +48,9 @@ jobs:
       uses: reactivecircus/android-emulator-runner@v2
       with:
         api-level: 30
-        # target: google_apis
         arch: x86_64
-        # profile: Nexus 6
-        emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
+        # S24 is -skin 1080x2340 -dpi-device 425 -prop qemu.sf.lcd_density=425
+        emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -skin 540x960 -dpi-device 240 -prop qemu.sf.lcd_density=240
         script: |
           ./gradlew connectedDebugAndroidTest createDebugCoverageReport
     - name: Show logcat

--- a/app/src/main/java/com/orbitals/colorfilter/MainActivity.java
+++ b/app/src/main/java/com/orbitals/colorfilter/MainActivity.java
@@ -435,6 +435,7 @@ public class MainActivity extends AppCompatActivity implements TextureView.Surfa
         } else {
             cameraController.reopenCamera();
         }
+        uiManager.adjustButtonVisibilityForScreenWidth();
     }
 
 
@@ -517,5 +518,4 @@ public class MainActivity extends AppCompatActivity implements TextureView.Surfa
         }
         filter.setUseLumSatBCT(prefs.getBoolean(SettingsActivity.KEY_SHOW_BCT_CONTROLS, filter.getUseLumSatBCT()));
     }
-
 }

--- a/app/src/main/java/com/orbitals/colorfilter/MainActivity.java
+++ b/app/src/main/java/com/orbitals/colorfilter/MainActivity.java
@@ -215,6 +215,12 @@ public class MainActivity extends AppCompatActivity implements TextureView.Surfa
                         filter.setSampleMode(!filter.getSampleMode());
                         updateControls();
                     }
+
+                    @Override
+                    public void onLightChanged() {
+                        cameraController.setLightMode(!cameraController.getLightMode());
+                        updateControls();
+                    }
                 },
                 filter.getHue(),
                 filter.getHueWidth(),
@@ -274,7 +280,8 @@ public class MainActivity extends AppCompatActivity implements TextureView.Surfa
                 filter.getCurrentTerm(),
                 filter.getTerm(),
                 updateSeekBars,
-                filter.getSampleMode()
+                filter.getSampleMode(),
+                cameraController.getLightMode()
         );
 
         if (isImageMode) {

--- a/app/src/main/res/drawable/baseline_flashlight_off_24.xml
+++ b/app/src/main/res/drawable/baseline_flashlight_off_24.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+    <path android:fillColor="?android:attr/textColorPrimary" android:pathData="M18,5l0,-3l-12,0l0,1.17l1.83,1.83z"/>
+    <path android:fillColor="?android:attr/textColorPrimary" android:pathData="M16,11l2,-3l0,-1l-8.17,0l6.17,6.17z"/>
+    <path android:fillColor="?android:attr/textColorPrimary" android:pathData="M2.81,2.81L1.39,4.22L8,10.83V22h8v-3.17l3.78,3.78l1.41,-1.41L2.81,2.81z"/>
+</vector>

--- a/app/src/main/res/drawable/baseline_flashlight_on_24.xml
+++ b/app/src/main/res/drawable/baseline_flashlight_on_24.xml
@@ -1,0 +1,6 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+
+    <path android:fillColor="?android:attr/textColorPrimary" android:pathData="M6,2h12v3h-12z"/>
+    <path android:fillColor="?android:attr/textColorPrimary" android:pathData="M6,7v1l2,3v11h8V11l2,-3V7H6zM12,15.5c-0.83,0 -1.5,-0.67 -1.5,-1.5s0.67,-1.5 1.5,-1.5s1.5,0.67 1.5,1.5S12.83,15.5 12,15.5z"/>
+    
+</vector>

--- a/app/src/main/res/drawable/baseline_more_vert_24.xml
+++ b/app/src/main/res/drawable/baseline_more_vert_24.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+
+    <path android:fillColor="?android:attr/textColorPrimary"  android:pathData="M12,8c1.1,0 2,-0.9 2,-2s-0.9,-2 -2,-2 -2,0.9 -2,2 0.9,2 2,2zM12,10c-1.1,0 -2,0.9 -2,2s0.9,2 2,2 2,-0.9 2,-2 -0.9,-2 -2,-2zM12,16c-1.1,0 -2,0.9 -2,2s0.9,2 2,2 2,-0.9 2,-2 -0.9,-2 -2,-2z"/>
+    
+</vector>

--- a/app/src/main/res/drawable/flashlight_button_selector.xml
+++ b/app/src/main/res/drawable/flashlight_button_selector.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/baseline_flashlight_off_24" android:state_selected="true"/>
+    <item android:drawable="@drawable/baseline_flashlight_on_24"/>
+</selector>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -171,7 +171,7 @@
             <Button
                 android:id="@+id/bctButton"
                 style="?android:attr/buttonBarButtonStyle"
-                android:layout_width="68dp"
+                android:layout_width="72dp"
                 android:layout_height="wrap_content"
                 android:ellipsize="none"
                 android:maxLines="1"
@@ -188,12 +188,28 @@
                 android:drawableStart="@drawable/sample_button_selector" />
 
             <Button
+                android:id="@+id/lightButton"
+                style="?android:attr/buttonBarButtonStyle"
+                android:layout_width="48dp"
+                android:layout_height="wrap_content"
+                android:contentDescription="@string/flashlight_button"
+                android:drawableStart="@drawable/flashlight_button_selector" />
+
+            <Button
                 android:id="@+id/settingsButton"
                 style="?android:attr/buttonBarButtonStyle"
                 android:layout_width="48dp"
                 android:layout_height="wrap_content"
                 android:contentDescription="@string/settings_button"
                 android:drawableStart="@drawable/baseline_settings_24" />
+            <Button
+                android:id="@+id/overflowMenuButton"
+                style="?android:attr/buttonBarButtonStyle"
+                android:layout_width="48dp"
+                android:layout_height="wrap_content"
+                android:contentDescription="@string/more_options"
+                android:drawableStart="@drawable/baseline_more_vert_24"
+                android:visibility="gone" />
         </LinearLayout>
 
     </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -40,4 +40,6 @@
     <string name="app_description">Identify colors by Basic Color Terms or hue in a live camera or image.</string>
     <string name="github_link">https://github.com/manthey/color-filter-app</string>
     <string name="sampling_mode">Sampling Mode</string>
+    <string name="flashlight_button">Flashlight</string>
+    <string name="more_options">More Options</string>
 </resources>


### PR DESCRIPTION
This adds an overflow menu for narrow screens, plus a flashlight button.

Technically, we should only show the light button is at least one camera supports a flash.  The alternative to hide the light button when the current camera doesn't support flash (or we are in image mode), but this makes the buttons bounce back and forth.  We could alternately disable the button.

Closes #27